### PR TITLE
Allow change of parent component size in AbstractTest

### DIFF
--- a/src/main/java/org/vaadin/addonhelpers/AbstractTest.java
+++ b/src/main/java/org/vaadin/addonhelpers/AbstractTest.java
@@ -2,7 +2,7 @@ package org.vaadin.addonhelpers;
 
 import org.apache.commons.lang3.StringUtils;
 
-import com.vaadin.server.VaadinRequest;
+import com.vaadin.server.*;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.UI;
@@ -19,9 +19,19 @@ public abstract class AbstractTest extends UI {
 
     protected void setup() {
         Component map = getTestComponent();
-        content.setSizeFull();
+        setContentSize(content);
         content.addComponent(map);
         content.setExpandRatio(map, 1);
+    }
+
+    /**
+     * Sets the size of the content. Override to change from
+     * {@link Sizeable#setSizeFull()}
+     * 
+     * @param content
+     */
+    public void setContentSize(Component content) {
+        content.setSizeFull();
     }
 
     public abstract Component getTestComponent();
@@ -34,7 +44,5 @@ public abstract class AbstractTest extends UI {
                     Notification.Type.WARNING_MESSAGE);
         }
     }
-    
-    
 
 }


### PR DESCRIPTION
Since we needed to show components with scrollbars in the browser, here is a way to set the parent content hight to undefined.